### PR TITLE
3_ページ全体の設定を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,9 +2,3 @@
  *= require_tree .
  *= require_self
  */
-
- .base-container {
-    max-width: 768px;
-    margin: 0 auto;
-    padding: 1rem;
-  }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,3 +2,9 @@
  *= require_tree .
  *= require_self
  */
+
+ .base-container {
+    max-width: 768px;
+    margin: 0 auto;
+    padding: 1rem;
+  }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,9 +7,21 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
 
   <body>
-    <%= yield %>
+    <header>
+    <h1></h1>
+    </header>
+    <main>
+      <div class="base-container">
+
+        <%= yield %>
+        
+      </div>
+    </main>
+    <footer>
+    </footer>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,9 +7,20 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
 
   <body>
-    <%= yield %>
+    <header>
+    </header>
+    <main>
+      <div class="base-container">
+
+        <%= yield %>
+        
+      </div>
+    </main>
+    <footer>
+    </footer>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,21 +7,9 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
 
   <body>
-    <header>
-    <h1></h1>
-    </header>
-    <main>
-      <div class="base-container">
-
-        <%= yield %>
-        
-      </div>
-    </main>
-    <footer>
-    </footer>
+    <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
### `app/views/layouts/application.html.erb`を編集しました。
- header,main,footerで３分割にしました。
- mainタグ内に`<div>`要素を配置し、クラス名`base-container`を付けました。更にその中に`<%= yeild %>`を配置しております。
- `<head>`内にスマホ用のビューポートを設定しました。

### `app/assets/stylesheets/application.css`を編集しました。
- クラスの`base-container`にプロパティと値を設定しました。

>参考資料：https://developers.google.com/web/fundamentals/design-and-ux/responsive?hl=ja#set-the-viewport
>参考資料：https://arcane-gorge-21903.herokuapp.com/texts/219