### PR TITLE
devise gem が /Gemfile の本番環境に適用されていないので、これを修正した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,13 +12,13 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
+gem 'devise'
+gem 'rails-i18n'
+gem 'devise-i18n'
+gem 'activeadmin'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'devise'
-
-  gem 'rails-i18n'
-  gem 'devise-i18n'
-  gem 'activeadmin'
 end
 
 group :development do


### PR DESCRIPTION
## 事の顛末は以下の通りです。
- devise gem が /Gemfile の development, test Group 内にエントリしたため、本番環境に適用されない状況であった。

## 以下の修正処置を取りました。
- devise gem をdevelopment, test Group から本番環境Group へ記載位置を改めた。
- devise gem と連携する gem (`rails-i18n`, `devise-i18n`)も同様に本番環境Group へ記載位置を改めた。
- 14_管理者画面の実装タスクで追加したactiveadmin gem も同様であったので、本番環境Group へ記載位置を改めた。
