### PR TITLE
17_AWSテキスト教材一覧ページの実装

### DIFF
--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -1,0 +1,7 @@
+class AwsTextsController < ApplicationController
+
+    def index
+        @aws_texts = AwsText.all
+    end
+
+end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,0 +1,23 @@
+<section >
+    <h2 class="text-center pt-5">AWS講座</h1>
+    <p>注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
+
+    <div class="table-container">
+        <table class="table table-striped">
+            <thead class="aws-text-table-head text-white">
+                <tr>
+                    <th class="w-1 bg-primary">No.</th>
+                    <th class="w-5 bg-primary">内容</th>
+                </tr>
+            </thead>
+            <tbody>
+            <% @aws_texts.each_with_index do |text ,id| %>
+                <tr>
+                    <td><%= id+1 %></td>
+                    <td><%= text.title %></td>
+                </tr>
+            <% end %>
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -11,9 +11,9 @@
                 </tr>
             </thead>
             <tbody>
-            <% @aws_texts.each_with_index do |text ,id| %>
+            <% @aws_texts.each.with_index(1) do |text ,id| %>
                 <tr>
-                    <td><%= id+1 %></td>
+                    <td><%= id %></td>
                     <td><%= text.title %></td>
                 </tr>
             <% end %>

--- a/app/views/movies/_navbar.html.erb
+++ b/app/views/movies/_navbar.html.erb
@@ -14,7 +14,7 @@
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
             <a class="dropdown-item" href="#">動画教材</a>
             <a class="dropdown-item" href="#">テキスト教材</a>
-            <a class="dropdown-item" href="#">AWS講座</a>
+            <a class="dropdown-item" href="/aws">AWS講座</a>
             <a class="dropdown-item" href="#">ライブコーディング</a>
             <a class="dropdown-item" href="#">質問集</a>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root 'movies#index'
-  
+  get '/aws', to: 'aws_texts#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root 'movies#index'
-  get '/aws', to: 'aws_texts#index'
+  resources :aws_texts, only: [:index]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
- AWS教材の一覧ページを作成
    - Bootstrapでスタイルリング
    - rake タスクで初期データを入れる

- ナビバーのAWS教材ページのリンクを動かす