### PR TITLE
19_Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,7 +48,6 @@ body {
 }
 
 .width-max{
-  margin:0 calc(50% - 50vw);
   max-width: 1020px;
   margin: 0 auto;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,7 +16,8 @@ body {
     padding-top: 80px;
   }
 
-.card {
+.video-card {
+  @extend .card;
   @extend .border-primary;
   @extend .rounded;
   background: #ddd;
@@ -44,4 +45,8 @@ body {
   content: "";
   display: block;
   padding-top: 80%;
+}
+
+.widthMax{
+  margin:0 calc(50% - 50vw);
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,6 +47,8 @@ body {
   padding-top: 80%;
 }
 
-.widthMax{
+.width-max{
   margin:0 calc(50% - 50vw);
+  max-width: 1020px;
+  margin: 0 auto;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,33 @@ body {
     // navbar-fixed-top 対応
     padding-top: 80px;
   }
+
+.card {
+  @extend .border-primary;
+  @extend .rounded;
+  background: #ddd;
+  border: 1px #ff0000 solid;
+  padding: 0 5px 0px;
+  margin-bottom: 5px;
+
+}
+.card-title {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.video-container {
+  position: relative;
+  overflow: hidden;
+}
+.video-expander {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 105%;
+}
+.ratio-1_1:before {
+  content: "";
+  display: block;
+  padding-top: 80%;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -2,6 +2,7 @@ class MoviesController < ApplicationController
   before_action :authenticate_user!
 
     def index
+      @movies = Movie.all
     end
 
 end

--- a/app/views/movies/_navbar.html.erb
+++ b/app/views/movies/_navbar.html.erb
@@ -12,7 +12,7 @@
             Rails
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-            <a class="dropdown-item" href="#">動画教材</a>
+            <%= link_to "動画教材", root_path, {class: "dropdown-item"} %>
             <a class="dropdown-item" href="#">テキスト教材</a>
             <a class="dropdown-item" href="#">AWS講座</a>
             <a class="dropdown-item" href="#">ライブコーディング</a>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,2 +1,17 @@
-<h1>top page</h1>
-<p>movies#index</p>
+<h1>動画教材一覧ページ</h1>
+<table class="table table-striped">
+  <thead class="table-primary">
+    <tr>
+      <th scope="col">No.</th>
+      <th scope="col">タイトル</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @movies.each.with_index(1) do |movie, index| %>
+    <tr>
+      <th scope="row" class="text-right"><%= index %></th>
+      <td class="text-nowrap"><%= link_to movie.title, movie.url %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,17 +1,14 @@
-<h1>動画教材一覧ページ</h1>
-<table class="table table-striped">
-  <thead class="table-primary">
-    <tr>
-      <th scope="col">No.</th>
-      <th scope="col">タイトル</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @movies.each.with_index(1) do |movie, index| %>
-    <tr>
-      <th scope="row" class="text-right"><%= index %></th>
-      <td class="text-nowrap"><%= link_to movie.title, movie.url %></td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="row justify-content-center">
+  <% @movies.each do |movie| %>
+    <div class="col-md-4">
+      <div class="card video-container h-100">
+        <div class="embed-responsive embed-responsive-16by9 video-expander">
+          <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
+        </div>
+        <div class="card-body">
+          <h4 class="card-title ratio-1_1"><%= movie.title %></h4>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,9 +1,9 @@
-<div class="row justify-content-center">
+<div class="row justify-content-center widthMax">
   <% @movies.each do |movie| %>
-    <div class="col-md-4">
-      <div class="card video-container h-100">
+    <div class="col-md-4 mb-5">
+      <div class="video-card video-container h-100">
         <div class="embed-responsive embed-responsive-16by9 video-expander">
-          <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
+          <iframe width="560" height="315" src="<%= movie.url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
         <div class="card-body">
           <h4 class="card-title ratio-1_1"><%= movie.title %></h4>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,4 @@
-<div class="row justify-content-center widthMax">
+<div class="row justify-content-center width-max">
   <% @movies.each do |movie| %>
     <div class="col-md-4 mb-5">
       <div class="video-card video-container h-100">


### PR DESCRIPTION
## 動画一覧ページを作成しました。
- `movies_controller.rb` で `Movie.all` を取得し、`index.html.erb`に`<table>` を使って表形式で表示しました。
- `rake import_csv:movies` を使って、`db/csv_data/movie_data.csv` のデータをMovieモデルへインポートしました。 
- `_navbar.html.erb` の"動画教材"のリンク先を動画一覧ページに設定しました。