### PR TITLE
FIX02_ application.scss　ActiveAdminのスタイル削除

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,3 @@
-/*
- *= require_tree .
- *= require_self
- */
-
 @import "bootstrap/scss/bootstrap";
 
 .base-container {


### PR DESCRIPTION
## 内容
・ `application.scss` にActiveAdminのスタイル

```/*
 *= require_tree .
 *= require_self
 */
```

が反映されてしまっていたため、削除して修正。

## 参考資料
・公式メンターたけさんの依頼文書