### PR TITLE
32_マネタイズ講座一覧ページの実装及び動画教材の視聴済みボタンの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,40 +16,119 @@ body {
     padding-top: 80px;
   }
 
-.video-card {
-  @extend .card;
-  @extend .border-primary;
-  @extend .rounded;
-  background: #ddd;
-  border: 1px #ff0000 solid;
-  padding: 0 5px 0px;
-  margin-bottom: 5px;
+#container{
+  @media screen and (min-width: 1200px){
+    width: 1200px;
+  }
+  @media screen and (min-width: 992px){
+    width: 990px;
+    padding: 120px 0 80px 0;
+    margin: 0 auto;
+  }
+  @media screen and (min-width: 0px){
+    width: 90%;
+    margin: 0 auto;
+    padding: 50px 0 160px 0;
+  }
+}
 
+.container-fluid{
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
 }
-.card-title {
-  width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.row {
+    display: flex;
+    flex-wrap: wrap;
+    margin-right: -15px;
+    margin-left: -15px;
 }
-.video-container {
+
+.video-card {
   position: relative;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background-color: #fff;
+  background-clip: border-box;
+  border: 1px solid rgba(0,0,0,0.125);
+  border-radius: 0.25rem;
 }
-.video-expander {
+.embed-responsive-16by9::before {
+  padding-top: 56.25%;
+}
+.embed-responsive::before {
+  display: block;
+  content: "";
+}
+.embed-responsive iframe{
   position: absolute;
   top: 0;
+  bottom: 0;
   left: 0;
-  width: 105%;
+  width: 100%;
+  height: 100%;
+  border: 0;
 }
-.ratio-1_1:before {
-  content: "";
-  display: block;
-  padding-top: 80%;
+
+.card-body {
+  flex: 1 1 auto;
+  min-height: 1px;
+  padding: 1.25rem;
 }
+
+.movie-body{
+  @media screen and (min-width: 992px){
+    height: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  @media screen and (min-width: 0px){
+    height: 290px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+#container p{
+  @media screen and (min-width: 992px){
+    font-size: 17px;
+  }
+  @media screen and (min-width: 0px){
+    font-size: 2.2em;
+    line-height: 1.9em;
+  }
+}
+
+@media screen and (min-width: 0px){
+  #container p.movie-title {
+      height: 200px;
+      font-size: 1.7rem;
+      line-height: 1.5em;
+  }
+}
+
+#container p{
+  @media screen and (min-width: 992px){
+    font-size: 17px;
+  }
+  @media screen and (min-width: 0px){
+    font-size: 2.2em;
+    line-height: 1.9em;
+  }
+}
+
+.card-text:last-child {
+    margin-bottom: 0;
+}
+
 .video-base-container {
   @extend .base-container;
-  max-width: 1020px;
-}
+  max-width: 1220px;
+} 
 
 .question-container {
   padding: 30px 0;

--- a/app/controllers/monetizes_controller.rb
+++ b/app/controllers/monetizes_controller.rb
@@ -1,0 +1,20 @@
+class MonetizesController < ApplicationController
+
+    def index
+        monetize_movies = AllMovie.where(category: "Money")
+        @movies = monetize_movies.page(params[:page]).per(12).all.order(id: "ASC")
+
+    end
+
+    def update
+        @movie = AllMovie.find(params[:id])
+        if @movie.watched_movie == false
+            @movie.watched_movie = true
+        else
+            @movie.watched_movie = false
+        end
+            @movie.save
+            redirect_to monetizes_path
+    end
+
+end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,7 +1,19 @@
 class MoviesController < ApplicationController
 
     def index
-      @movies = Movie.page(params[:page]).per(12)
+      
+      @movies = Movie.page(params[:page]).per(12).all.order(id: "ASC")
+    end
+
+    def update
+      @movie = Movie.find(params[:id])
+      if @movie.watched_movie == false
+        @movie.watched_movie = true
+      else
+        @movie.watched_movie = false
+      end
+        @movie.save
+        redirect_to root_path
     end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ require "coderay"
 module ApplicationHelper
 
   def base_container
-    if controller_name == "movies"
+    if controller_name == "movies" || "monetizes"
       "video-base-container"
     elsif controller_name == "ruby_rails_texts"
       "ruby-rails-base-container"

--- a/app/models/all_movie.rb
+++ b/app/models/all_movie.rb
@@ -1,0 +1,4 @@
+class AllMovie < ApplicationRecord
+    validates :title, presence: true
+    validates :url, presence: true
+end

--- a/app/views/monetizes/index.html.erb
+++ b/app/views/monetizes/index.html.erb
@@ -1,3 +1,2 @@
 <%= render 'movies/card' %>
 
-

--- a/app/views/movies/_card.html.erb
+++ b/app/views/movies/_card.html.erb
@@ -1,0 +1,38 @@
+<div id="container">
+    <div class="container-fluid">
+        <div class="row">
+            <% @movies.each do |movie| %>
+                <div class="col-12 col-md-6 col-lg-4">
+                    <div class="video-card border-dark mb-3">
+                        <div class="card-header p-0">
+                            <div class="embed-responsive embed-responsive-16by9">
+                                <iframe width="560" height="315" src="<%= movie.url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            </div>
+                            <div class="card-body text-dark movie-body">
+                                <p id="watched-movie-<%= movie.id %>">
+                                    
+                                        <% if movie.watched_movie == false %>
+                                            <% if controller_name == "movies" %>
+                                                <%= link_to '視聴済みにする', movie_path(movie.id), method: :patch, class: "btn btn-secondary btn-block" %>
+                                            <% else %>
+                                                <%= link_to '視聴済みにする', monetize_path(movie.id), method: :patch, class: "btn btn-secondary btn-block" %>
+                                            <% end %>
+                                        <% else %>
+                                            <% if controller_name == "movies" %>
+                                                <%= link_to '視聴済みを解除', movie_path(movie.id), method: :patch, class: "btn btn-primary btn-block" %>
+                                            <% else %>
+                                                <%= link_to '視聴済みを解除', monetize_path(movie.id), method: :patch, class: "btn btn-primary btn-block" %>
+                                            <% end%>
+                                        <% end %>
+                                    
+                                </p>
+                                <p class="card-text movie-title"><%= movie.title %></p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <% end %>
+        </div>
+        <%= paginate @movies %>
+    </div>
+</div>

--- a/app/views/movies/_navbar.html.erb
+++ b/app/views/movies/_navbar.html.erb
@@ -38,7 +38,7 @@
           <a class="nav-link" href="#">ライティング講座</a>
         </li>
         <li class="nav-item active">
-          <a class="nav-link" href="#">マネタイズ講座</a>
+          <%= link_to "マネタイズ講座", monetizes_path,{class: "nav-link"} %>
         <li class="nav-item active">
           <%= link_to "LINE@", line_texts_path,{class: "nav-link"} %>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,13 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root 'movies#index'
+  resources :movies, only: [:index, :update]
   resources :aws_texts, only: [:index]
   resources :questions, only: [:index, :show, :create] do
     resources :solutions, only: [:index, :create]
   end
   resources :ruby_rails_texts, only: [:index, :show]
   resources :line_texts, only: [:index, :show]
+  resources :monetizes, only: [:index, :update]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20200725043253_create_all_movies.rb
+++ b/db/migrate/20200725043253_create_all_movies.rb
@@ -1,0 +1,11 @@
+class CreateAllMovies < ActiveRecord::Migration[6.0]
+  def change
+    create_table :all_movies do |t|
+      t.string :title
+      t.string :url
+      t.string :category
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200725075030_add_watched_movies_to_movies.rb
+++ b/db/migrate/20200725075030_add_watched_movies_to_movies.rb
@@ -1,0 +1,5 @@
+class AddWatchedMoviesToMovies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :movies, :watched_movie, :boolean, default: false
+  end
+end

--- a/db/migrate/20200725124633_add_watch_movies_to_all_movies.rb
+++ b/db/migrate/20200725124633_add_watch_movies_to_all_movies.rb
@@ -1,0 +1,5 @@
+class AddWatchMoviesToAllMovies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :all_movies, :watched_movie, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_16_073903) do
+ActiveRecord::Schema.define(version: 2020_07_25_124633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,15 @@ ActiveRecord::Schema.define(version: 2020_07_16_073903) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
+  create_table "all_movies", force: :cascade do |t|
+    t.string "title"
+    t.string "url"
+    t.string "category"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.boolean "watched_movie", default: false
+  end
+
   create_table "aws_texts", force: :cascade do |t|
     t.string "title"
     t.text "content"
@@ -62,6 +71,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_073903) do
     t.string "category"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "watched_movie", default: false
   end
 
   create_table "questions", force: :cascade do |t|

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -19,6 +19,15 @@ namespace :import_csv do
         Movie.create!(list)
     end
 
+    # rake import_csv:all_movies コマンドで
+    # all_movie_dataファイルからデータベースにインポートできます
+    desc "AllMovie CSVデータのインポート"
+    task all_movies: :environment do
+        # インポートしたオブジェクト（Rails動画教材）を変数listに代入
+        list = Import.csv_data(path: 'db/csv_data/all_movie_data.csv')
+        AllMovie.create!(list)
+    end
+
     # rake import_csv:questions コマンドで
     # question_dataファイルからデータベースにインポートできます
     desc "Quiestion CSVデータのインポート"


### PR DESCRIPTION
- navbar のマネタイズ講座をクリックすると、マネタイズ講座一覧ページに案内されるようにしました。

- rakeタスクに`all_movie_date.csv`を追加しました。

- マネタイズ講座一覧ページを作成しました。

- AllMovie.where(category: "Money") の結果をビューに表示しました。

- ビューの`movies`と`monetizes`との冗長化を避ける為、動画コンテナを`movies/card`雛形をまとめました。

- movieテーブルとall_movieテーブルに`watched_movie:boolean`カラムを追加しました。

- `movie/card`に「視聴済み/解除」ボタンを実装しました。（Ajax通信は未実装です）
