### PR TITLE
18_AWSテキスト教材詳細ページの実装

### DIFF
--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -4,4 +4,8 @@ class AwsTextsController < ApplicationController
         @aws_texts = AwsText.all
     end
 
+    def show
+        @aws_text = AwsText.find(params[:id])
+    end
+
 end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,5 +1,5 @@
-<section >
-    <h2 class="text-center pt-5">AWS講座</h1>
+<section>
+    <h1 class="text-center pt-5">AWS講座</h1>
     <p>注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
 
     <div class="table-container">
@@ -13,7 +13,7 @@
             <tbody>
             <% @aws_texts.each.with_index(1) do |aws_text ,id| %>
                 <tr>
-                    <th scope="row"><td><%= id %></td>
+                    <th scope="row"><%= id %></th>
                     <td><%= link_to "#{aws_text.title}", aws_text_path(aws_text) %></td>
                 </tr>
             <% end %>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -11,10 +11,10 @@
                 </tr>
             </thead>
             <tbody>
-            <% @aws_texts.each.with_index(1) do |text ,id| %>
+            <% @aws_texts.each.with_index(1) do |aws_text ,id| %>
                 <tr>
-                    <td><%= id %></td>
-                    <td><%= text.title %></td>
+                    <th scope="row"><td><%= id %></td>
+                    <td><%= link_to "#{aws_text.title}", aws_text_path(aws_text) %></td>
                 </tr>
             <% end %>
             </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,2 @@
+<h2><%= @aws_text.title %></h2>
+<p><%= markdown(@aws_text.content).html_safe %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root 'movies#index'
-  resources :aws_texts, only: [:index]
+  resources :aws_texts, only: [:index, :show]
   resources :questions, only: [:index, :show, :create] do
     resources :solutions, only: [:index, :create]
   end


### PR DESCRIPTION
## 内容
#### 一覧ページの「内容」から詳細ページに移動できるようにする
・`app/views/aws_texts/index.html.erb` をlink_toメソッドを使用し詳細ページに遷移できるよう改修 
・`routes.rb`の`aws_texts`に`show`を追加しルーティング設定
・`aws_texts_controller.rb`に`show`アクションを追加

#### 詳細ページの作成（ Markdownに対応した表示ができるように対応）
・`rake import_csv:aws_texts`コマンドで `aws_text_data.csv` を `aws_texts` テーブルにインポート
・`views / aws_texts`に`show.html.erb`をMarkdown表示できるよう追加

## 参考資料
・逆転教材（テキスト）メッセージ投稿アプリ（その1・CRUD処理）
https://arcane-gorge-21903.herokuapp.com/texts/269
・逆転教材（テキスト）RailsアプリへのMarkdownの導入
https://arcane-gorge-21903.herokuapp.com/texts/224
・逆転教材（テキスト）Rakeタスク  
https://arcane-gorge-21903.herokuapp.com/texts/218
・逆転教材（テキスト）Bootstrap教材（その1）
https://arcane-gorge-21903.herokuapp.com/texts/260