### PR TITLE
30_アカウント編集ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -337,3 +337,8 @@ body {
   }
 
 }
+
+.account-edit-title {
+  margin: 100px 0px 15px;
+}
+

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,6 @@
-<br><br><br><br>
-<h2><%= t('アカウント編集', resource: resource_name.to_s.humanize) %></h2>
+<div class="account-edit-title">
+  <h2><%= t('アカウント編集', resource: resource_name.to_s.humanize) %></h2>
+</div>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
@@ -32,10 +33,8 @@
     <%= f.submit t('.update'), class: 'btn btn-primary btn-block' %>
   </div>
 
-  <br>
-  <hr>
-  <br>
-  <div class="form-group">
+  <hr class="link my-5">
+  <div>
     <a class="btn btn-info btn-block" href="/">トップページ</a>
   </div>
 <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,5 @@
-<h1><%= t('.title', resource: resource_name.to_s.humanize) %></h1>
+<br><br><br><br>
+<h2><%= t('アカウント編集', resource: resource_name.to_s.humanize) %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
@@ -28,10 +29,14 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.update'), class: 'btn btn-primary' %>
+    <%= f.submit t('.update'), class: 'btn btn-primary btn-block' %>
+  </div>
+
+  <br>
+  <hr>
+  <br>
+  <div class="form-group">
+    <a class="btn btn-info btn-block" href="/">トップページ</a>
   </div>
 <% end %>
 
-<p><%= t('.unhappy') %>? <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %>.</p>
-
-<%= link_to t('.back'), :back %>

--- a/app/views/movies/_navbar.html.erb
+++ b/app/views/movies/_navbar.html.erb
@@ -44,7 +44,7 @@
         </li>
         <% if user_signed_in? %>
           <li class="nav-item active">
-            <%= link_to "アカウント編集", destroy_user_session_path, method: :delete, class: "nav-link" %>
+            <%= link_to "アカウント編集", edit_user_registration_path,  class: "nav-link" %>
           </li>
           <li class="nav-item active">
             <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-link" %>


### PR DESCRIPTION
## 内容
・`app/views/movies/_navbar.html.erb` をlink_toメソッドを使用し、アカウント編集ページに遷移できるよう改修 
・`app/views/devise/registrations/edit.html.erb`のデザインを改修、Bootstrapのフォームを使用し、トップページに遷移できるよう改修
・`application.scss`の`account-edit-title`クラスに、mariginを追加し改修

## 参考資料
・逆転教材　ログイン機能
https://arcane-gorge-21903.herokuapp.com/texts/219
・逆転教材　Bootstrap教材（その1）
https://arcane-gorge-21903.herokuapp.com/texts/260
・Deviseでログイン機能を追加・日本語化・Bootstrap4適用まで
https://qiita.com/take18k_tech/items/a36d77316e32a6696205